### PR TITLE
Move DNS-based email verifier

### DIFF
--- a/src/email/__init__.py
+++ b/src/email/__init__.py
@@ -1,3 +1,4 @@
 from .email_pattern_generator import EmailPatternGenerator
+from .dns_email_verifier import DNSEmailVerifier
 
-__all__ = ["EmailPatternGenerator"]
+__all__ = ["EmailPatternGenerator", "DNSEmailVerifier"]

--- a/src/email/dns_email_verifier.py
+++ b/src/email/dns_email_verifier.py
@@ -1,0 +1,46 @@
+"""Email verification via DNS MX record lookup."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+import dns.resolver
+
+
+class DNSEmailVerifier:
+    """Check whether an email's domain has MX records."""
+
+    def __init__(self, cache: Dict[str, bool] | None = None, timeout: float = 2.0) -> None:
+        """Create a new verifier.
+
+        Parameters
+        ----------
+        cache:
+            Optional dictionary used to cache domain lookups for speed.
+        timeout:
+            DNS resolution timeout in seconds.
+        """
+        self.cache: Dict[str, bool] = cache or {}
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    def verify(self, email: str) -> bool:
+        """Return ``True`` if the domain of ``email`` has MX records."""
+        match = re.search(r"@([^@]+)$", email)
+        if not match:
+            return False
+
+        domain = match.group(1).lower().strip()
+        if domain in self.cache:
+            return self.cache[domain]
+
+        try:
+            dns.resolver.resolve(domain, "MX", lifetime=self.timeout)
+            self.cache[domain] = True
+        except dns.resolver.DNSException:
+            self.cache[domain] = False
+        return self.cache[domain]
+
+
+__all__ = ["DNSEmailVerifier"]

--- a/src/validators/__init__.py
+++ b/src/validators/__init__.py
@@ -1,0 +1,7 @@
+"""Validation utilities for executive discovery."""
+
+from .domain_validator import DomainValidator
+from .name_validator import NameValidator
+from ..email.dns_email_verifier import DNSEmailVerifier
+
+__all__ = ["DomainValidator", "NameValidator", "DNSEmailVerifier"]


### PR DESCRIPTION
## Summary
- move `dns_email_verifier` module under the `email` package
- adjust exports so `DNSEmailVerifier` is available from both `email` and `validators`

## Testing
- `python -m py_compile $(git ls-files '*.py')`